### PR TITLE
Client rocket jump test

### DIFF
--- a/HenryMod/Components/NetworkedBodyBlastJumpHandler.cs
+++ b/HenryMod/Components/NetworkedBodyBlastJumpHandler.cs
@@ -17,11 +17,11 @@ namespace RocketSurvivor.Components
             characterBody = base.GetComponent<CharacterBody>();
         }
 
-        [ClientRpc]
+        /*[ClientRpc]
         public void RpcBlastJump(Vector3 position, float radius, float force, float horizontalMultiplier, bool requireAirborne)
         {
             BlastJumpAuthority(position, radius, force, horizontalMultiplier, requireAirborne);
-        }
+        }*/
 
         public void BlastJumpAuthority(Vector3 position, float radius, float force, float horizontalMultiplier, bool requireAirborne)
         {

--- a/HenryMod/Components/NetworkedBodyBlastJumpHandler.cs
+++ b/HenryMod/Components/NetworkedBodyBlastJumpHandler.cs
@@ -17,11 +17,11 @@ namespace RocketSurvivor.Components
             characterBody = base.GetComponent<CharacterBody>();
         }
 
-        /*[ClientRpc]
+        [ClientRpc]
         public void RpcBlastJump(Vector3 position, float radius, float force, float horizontalMultiplier, bool requireAirborne)
         {
             BlastJumpAuthority(position, radius, force, horizontalMultiplier, requireAirborne);
-        }*/
+        }
 
         public void BlastJumpAuthority(Vector3 position, float radius, float force, float horizontalMultiplier, bool requireAirborne)
         {

--- a/HenryMod/Components/Projectile/AddToRocketTrackerComponent.cs
+++ b/HenryMod/Components/Projectile/AddToRocketTrackerComponent.cs
@@ -13,16 +13,13 @@ namespace RocketSurvivor.Components.Projectile
 
         public void Start()
         {
-            if (NetworkServer.active)
+            ProjectileController pc = base.GetComponent<ProjectileController>();
+            if (pc && pc.owner)
             {
-                ProjectileController pc = base.GetComponent<ProjectileController>();
-                if (pc && pc.owner)
+                RocketTrackerComponent rtc = pc.owner.GetComponent<RocketTrackerComponent>();
+                if (rtc)
                 {
-                    RocketTrackerComponent rtc = pc.owner.GetComponent<RocketTrackerComponent>();
-                    if (rtc)
-                    {
-                        rtc.AddRocket(base.gameObject, applyAirDetBonus, isC4);
-                    }
+                    rtc.AddRocket(base.gameObject, applyAirDetBonus, isC4); //Add on both client and server so clients can immediately trigger blast jump from M2.
                 }
             }
             Destroy(this);

--- a/HenryMod/Components/Projectile/AddToRocketTrackerComponent.cs
+++ b/HenryMod/Components/Projectile/AddToRocketTrackerComponent.cs
@@ -14,11 +14,20 @@ namespace RocketSurvivor.Components.Projectile
         public void Start()
         {
             ProjectileController pc = base.GetComponent<ProjectileController>();
+            Debug.Log("Attempting add rocket");
             if (pc && pc.owner)
             {
                 RocketTrackerComponent rtc = pc.owner.GetComponent<RocketTrackerComponent>();
                 if (rtc)
                 {
+                    if (isC4)
+                    {
+                        Debug.Log("Adding C4");
+                    }
+                    else
+                    {
+                        Debug.Log("Adding Rocket");
+                    }
                     rtc.AddRocket(base.gameObject, applyAirDetBonus, isC4); //Add on both client and server so clients can immediately trigger blast jump from M2.
                 }
             }

--- a/HenryMod/Components/Projectile/AddToRocketTrackerComponent.cs
+++ b/HenryMod/Components/Projectile/AddToRocketTrackerComponent.cs
@@ -14,20 +14,11 @@ namespace RocketSurvivor.Components.Projectile
         public void Start()
         {
             ProjectileController pc = base.GetComponent<ProjectileController>();
-            Debug.Log("Attempting add rocket");
             if (pc && pc.owner)
             {
                 RocketTrackerComponent rtc = pc.owner.GetComponent<RocketTrackerComponent>();
                 if (rtc)
                 {
-                    if (isC4)
-                    {
-                        Debug.Log("Adding C4");
-                    }
-                    else
-                    {
-                        Debug.Log("Adding Rocket");
-                    }
                     rtc.AddRocket(base.gameObject, applyAirDetBonus, isC4); //Add on both client and server so clients can immediately trigger blast jump from M2.
                 }
             }

--- a/HenryMod/Components/Projectile/BlastJumpComponent.cs
+++ b/HenryMod/Components/Projectile/BlastJumpComponent.cs
@@ -63,13 +63,15 @@ namespace RocketSurvivor.Components.Projectile
 
         public void BlastJump()
         {
-            if (fired || (pd && pd.force <= 0f) || !pc || !pc.owner) return;
+            Debug.Log("Attempting blast jump");
+            if (fired || !pc || !pc.owner || (pd && pd.force <= 0f)) return;
 
             NetworkedBodyBlastJumpHandler nb = pc.owner.GetComponent<NetworkedBodyBlastJumpHandler>();
             if (nb && nb.hasAuthority)
             {
                 fired = true;
                 nb.BlastJumpAuthority(base.transform.position, aoe, force, horizontalMultiplier, requireAirborne);
+                if (!triggerOnImpact) Debug.Log("Triggered Blast Jump on C4");
             }
         }
 

--- a/HenryMod/Components/Projectile/ProjectileImpactBlastJump.cs
+++ b/HenryMod/Components/Projectile/ProjectileImpactBlastJump.cs
@@ -1,0 +1,17 @@
+﻿using RoR2;
+using RoR2.Projectile;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace RocketSurvivor.Components.Projectile
+{
+    public class ProjectileImpactBlastJump : MonoBehaviour, IProjectileImpactBehavior
+    {
+        public void OnProjectileImpact(ProjectileImpactInfo impactInfo)
+        {
+            BlastJumpComponent bjc = base.GetComponent<BlastJumpComponent>();
+            if (bjc) bjc.BlastJump();
+        }
+    }
+}

--- a/HenryMod/Components/RocketTrackerComponent.cs
+++ b/HenryMod/Components/RocketTrackerComponent.cs
@@ -109,6 +109,23 @@ namespace RocketSurvivor.Components {
             ProjectileController pc = toDetonate.GetComponent<ProjectileController>();
             ProjectileImpactExplosion pie = toDetonate.GetComponent<ProjectileImpactExplosion>();
             TeamFilter tf = toDetonate.GetComponent<TeamFilter>();
+            BlastJumpComponent bjc = toDetonate.GetComponent<BlastJumpComponent>();
+
+            if (bjc && bjc.runOnServer)
+            {
+                float origAoe = bjc.aoe;
+                float origForce = bjc.force;
+                if (info.applyAirDetBonus)
+                {
+                    bjc.aoe *= EntityStates.RocketSurvivorSkills.Secondary.AirDet.radiusMult;
+                    bjc.force *= EntityStates.RocketSurvivorSkills.Secondary.AirDet.forceMult;
+                }
+                bjc.AttemptBlastJump();
+
+                //Reset these in case it attempts to stack after a failed detonation or something weird.
+                bjc.aoe = origAoe;
+                bjc.force = origForce;
+            }
 
             if (pc && pie)
             {
@@ -245,7 +262,7 @@ namespace RocketSurvivor.Components {
             GameObject toDetonate = info.gameObject;
             BlastJumpComponent bjc = toDetonate.GetComponent<BlastJumpComponent>();
 
-            if (!bjc) return;
+            if (!bjc || bjc.runOnServer) return;
 
             float origAoe = bjc.aoe;
             float origForce = bjc.force;
@@ -254,7 +271,7 @@ namespace RocketSurvivor.Components {
                 bjc.aoe *= EntityStates.RocketSurvivorSkills.Secondary.AirDet.radiusMult;
                 bjc.force *= EntityStates.RocketSurvivorSkills.Secondary.AirDet.forceMult;
             }
-            bjc.BlastJump();
+            bjc.AttemptBlastJump();
 
             //Reset these in case it attempts to stack after a failed detonation or something weird.
             bjc.aoe = origAoe;

--- a/HenryMod/Components/RocketTrackerComponent.cs
+++ b/HenryMod/Components/RocketTrackerComponent.cs
@@ -18,8 +18,8 @@ namespace RocketSurvivor.Components {
         public static NetworkSoundEventDef detonateSuccess;
         public static NetworkSoundEventDef detonateFail;
 
-        [SyncVar]
-        private bool _rocketAvailable = false;
+        //[SyncVar]
+        //private bool _rocketAvailable = false;
 
         public void Awake()
         {
@@ -31,10 +31,10 @@ namespace RocketSurvivor.Components {
         public void FixedUpdate()
         {
             ClearEmptyRockets();
-            if (NetworkServer.active)
+            /*if (NetworkServer.active)
             {
                 UpdateRocketAvailable();
-            }
+            }*/
         }
 
         public void OnDestroy()
@@ -54,7 +54,7 @@ namespace RocketSurvivor.Components {
             rocketList.RemoveAll(item => item.gameObject == null);
         }
 
-        [Server]
+        /*[Server]
         private void UpdateRocketAvailable()
         {
             if (!NetworkServer.active) return;
@@ -69,11 +69,12 @@ namespace RocketSurvivor.Components {
             {
                 _rocketAvailable = newRocketAvailable;
             }
-        }
+        }*/
 
         public bool IsRocketAvailable()
         {
-            return _rocketAvailable;
+            return rocketList.Count + c4List.Count > 0;
+            //return _rocketAvailable;
         }
 
         public void AddRocket(GameObject rocket, bool applyAirDetBuff, bool isC4 = false)
@@ -215,7 +216,8 @@ namespace RocketSurvivor.Components {
                         detonatedSuccessfully = detonatedSuccessfully || detonate;
                     }
                 }
-                UpdateRocketAvailable();
+                ClearEmptyRockets();
+                //UpdateRocketAvailable();
             }
             return detonatedSuccessfully;
         }
@@ -235,11 +237,13 @@ namespace RocketSurvivor.Components {
             if (NetworkServer.active)
             {
                 bool success = DetonateRocket();
-                EffectManager.SimpleSoundEffect(success ? detonateSuccess.index : detonateFail.index, base.transform.position, true); //Moved from AirDet.cs to here
+
+                //No need for this anymore since the detonation check is Clientside and ensures that you'll at least get to blast jump if you trigger it.
+                /*EffectManager.SimpleSoundEffect(success ? detonateSuccess.index : detonateFail.index, base.transform.position, true); //Moved from AirDet.cs to here
                 if (!success)
                 {
-                    RpcAddSecondaryStock();
-                }
+                    RpcAddSecondaryStock();   
+                }*/
             }
         }
 

--- a/HenryMod/Components/RocketTrackerComponent.cs
+++ b/HenryMod/Components/RocketTrackerComponent.cs
@@ -65,7 +65,10 @@ namespace RocketSurvivor.Components {
                 newRocketAvailable = true;
             }
 
-            if (newRocketAvailable != _rocketAvailable) _rocketAvailable = newRocketAvailable;
+            if (newRocketAvailable != _rocketAvailable)
+            {
+                _rocketAvailable = newRocketAvailable;
+            }
         }
 
         public bool IsRocketAvailable()
@@ -240,11 +243,9 @@ namespace RocketSurvivor.Components {
         {
             if (!info.gameObject) return;
             GameObject toDetonate = info.gameObject;
-            ProjectileController pc = toDetonate.GetComponent<ProjectileController>();
-            ProjectileImpactExplosion pie = toDetonate.GetComponent<ProjectileImpactExplosion>();
             BlastJumpComponent bjc = toDetonate.GetComponent<BlastJumpComponent>();
 
-            if (!pc || !pie || !bjc) return;
+            if (!bjc) return;
 
             float origAoe = bjc.aoe;
             float origForce = bjc.force;

--- a/HenryMod/Modules/Projectiles.cs
+++ b/HenryMod/Modules/Projectiles.cs
@@ -194,6 +194,7 @@ namespace RocketSurvivor.Modules
             bjc.force = 3600f;
             bjc.horizontalMultiplier = 1f;
             bjc.requireAirborne = false;
+            bjc.triggerOnImpact = false;
 
             ProjectileDamage pd = c4Projectile.GetComponent<ProjectileDamage>();
             pd.damageType = DamageType.Stun1s;

--- a/HenryMod/RocketSurvivorPlugin.cs
+++ b/HenryMod/RocketSurvivorPlugin.cs
@@ -35,7 +35,7 @@ namespace RocketSurvivor
     {
         public const string MODUID = "com.EnforcerGang.RocketSurvivor";
         public const string MODNAME = "RocketSurvivor";
-        public const string MODVERSION = "0.7.3";
+        public const string MODVERSION = "0.8.0";
 
         // a prefix for name tokens to prevent conflicts- please capitalize all name tokens for convention
         public const string DEVELOPER_PREFIX = "MOFFEIN";

--- a/HenryMod/SkillStates/RocketSurvivor/Primary/FireRocket.cs
+++ b/HenryMod/SkillStates/RocketSurvivor/Primary/FireRocket.cs
@@ -42,7 +42,8 @@ namespace EntityStates.RocketSurvivorSkills.Primary
 					Ray aimRay2 = new Ray(aimRay.origin, direction);
 					for (int i = 0; i < 3; i++)
 					{
-						ProjectileManager.instance.FireProjectile(FireRocket.projectilePrefab, aimRay2.origin, Util.QuaternionSafeLookRotation(aimRay2.direction), base.gameObject, damageMult * this.damageStat * FireRocket.damageCoefficient, ((i != 1 && !RocketSurvivor.Modules.Config.pocketICBMEnableKnockback.Value) ? 0f : FireRocket.force), base.RollCrit(), DamageColorIndex.Default, null, -1f);
+						bool isCenterRocket = i != 1 && !RocketSurvivor.Modules.Config.pocketICBMEnableKnockback.Value;
+						ProjectileManager.instance.FireProjectile(isCenterRocket ? FireRocket.projectilePrefabICBM : FireRocket.projectilePrefab, aimRay2.origin, Util.QuaternionSafeLookRotation(aimRay2.direction), base.gameObject, damageMult * this.damageStat * FireRocket.damageCoefficient, isCenterRocket ? 0f : FireRocket.force, base.RollCrit(), DamageColorIndex.Default, null, -1f);
 						aimRay2.direction = rotation * aimRay2.direction;
 					}
 				}
@@ -72,6 +73,7 @@ namespace EntityStates.RocketSurvivorSkills.Primary
 		public static string muzzleString = "MuzzleRocketLauncher";
 		public static string attackSoundString = "Play_Moffein_RocketSurvivor_M1_Shoot";
 		public static GameObject projectilePrefab;
+		public static GameObject projectilePrefabICBM;
 		public static GameObject effectPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Common/VFX/MuzzleflashBarrage.prefab").WaitForCompletion();
 		public static float damageCoefficient = 6f;
 		public static float force = 2000f;

--- a/HenryMod/SkillStates/RocketSurvivor/Primary/FireRocketAlt.cs
+++ b/HenryMod/SkillStates/RocketSurvivor/Primary/FireRocketAlt.cs
@@ -42,13 +42,14 @@ namespace EntityStates.RocketSurvivorSkills.Primary
 					Ray aimRay2 = new Ray(aimRay.origin, direction);
 					for (int i = 0; i < 3; i++)
 					{
-						ProjectileManager.instance.FireProjectile(FireRocketAlt.projectilePrefab, aimRay2.origin, Util.QuaternionSafeLookRotation(aimRay2.direction), base.gameObject, damageMult * this.damageStat * FireRocket.damageCoefficient, ((i != 1 && !RocketSurvivor.Modules.Config.pocketICBMEnableKnockback.Value) ? 0f : FireRocket.force), base.RollCrit(), DamageColorIndex.Default, null, -1f);
+						bool isCenterRocket = i != 1 && !RocketSurvivor.Modules.Config.pocketICBMEnableKnockback.Value;
+						ProjectileManager.instance.FireProjectile(isCenterRocket ? FireRocketAlt.projectilePrefabICBM : FireRocketAlt.projectilePrefab, aimRay2.origin, Util.QuaternionSafeLookRotation(aimRay2.direction), base.gameObject, damageMult * this.damageStat * FireRocketAlt.damageCoefficient, isCenterRocket ? 0f : FireRocketAlt.force, base.RollCrit(), DamageColorIndex.Default, null, -1f);
 						aimRay2.direction = rotation * aimRay2.direction;
 					}
 				}
 				else
 				{
-					ProjectileManager.instance.FireProjectile(FireRocketAlt.projectilePrefab, aimRay.origin, Util.QuaternionSafeLookRotation(aimRay.direction), base.gameObject, this.damageStat * FireRocket.damageCoefficient, FireRocket.force, base.RollCrit(), DamageColorIndex.Default, null, -1f);
+					ProjectileManager.instance.FireProjectile(FireRocketAlt.projectilePrefab, aimRay.origin, Util.QuaternionSafeLookRotation(aimRay.direction), base.gameObject, this.damageStat * FireRocketAlt.damageCoefficient, FireRocketAlt.force, base.RollCrit(), DamageColorIndex.Default, null, -1f);
 				}
 			}
 		}
@@ -72,6 +73,7 @@ namespace EntityStates.RocketSurvivorSkills.Primary
 		public static string muzzleString = "MuzzleRocketLauncher";
 		public static string attackSoundString = "Play_Moffein_RocketSurvivor_M1_Alt_Shoot";
 		public static GameObject projectilePrefab;
+		public static GameObject projectilePrefabICBM;
 		public static GameObject effectPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Common/VFX/MuzzleflashBarrage.prefab").WaitForCompletion();
 		public static float damageCoefficient = 6f;
 		public static float force = 2250f;

--- a/HenryMod/SkillStates/RocketSurvivor/Secondary/AirDet.cs
+++ b/HenryMod/SkillStates/RocketSurvivor/Secondary/AirDet.cs
@@ -25,13 +25,11 @@ namespace EntityStates.RocketSurvivorSkills.Secondary
         {
             base.OnEnter();
 
-            if (NetworkServer.active)
+            RocketTrackerComponent rtc = base.GetComponent<RocketTrackerComponent>();
+            if (rtc)
             {
-                RocketTrackerComponent rtc = base.GetComponent<RocketTrackerComponent>();
-                if (rtc)
-                {
-                    rtc.ServerDetonateRocket();
-                }
+                if (base.isAuthority) rtc.ClientDetonateBlastJump();
+                if (NetworkServer.active) rtc.ServerDetonateRocket();
             }
 
             PlayAnimation("LeftArm, Override", "RemoteDet");


### PR DESCRIPTION
- Fixed SAM Launcher using the default primary's Force and Damage values when not carrying Pocket ICBM.
- Netcode Overhaul
	- HG4 Rocket Launcher: Major Improvement
		- Blast jumping is mostly clientside now.
			- Blast jump AoE might not line up with the projectile visual at times when playing online, but rapid detonating to blast jump with M2 should work a lot better now.
		
	- Nitro Charge: Improved
		- Blast jump is clientside when detonating with Remote Detonator.
		- Position is still server-side, so it won't be as responsive as the default primary.
		
	- HG4 SAM Launcher: No Change (Technical Limitations)
		- New rocket stuff doesn't work with this because of the homing (forces prediction to be disabled).
			- Nitro Charge also has prediction disabled, but doesnt rely on impact detonation which is why it can benefit from clientside blast jumps.
	
	- Remote Detonator
		- Blast jump immediately triggers for clients.
			- SAM Launcher does not benefit from this.
		- Rocket/Projectile counter is now client-side instead of server-side.
			- This makes blast jumping more responsive but can cause cases where you dont actually detonate the projectile on the server.